### PR TITLE
Hide sr-only elements

### DIFF
--- a/resources/views/infolists/components/print-filament.blade.php
+++ b/resources/views/infolists/components/print-filament.blade.php
@@ -24,7 +24,7 @@
                 color: #000 !important;
                 color: #000;
             }
-            .btn, #print-button, .fi-sidebar, .fi-breadcrumbs, .fi-topbar {
+            .btn, #print-button, .fi-sidebar, .fi-breadcrumbs, .fi-topbar, .sr-only {
                 display: none;
             }
         }


### PR DESCRIPTION
This PR ensures elements with the sr-only class are properly hidden.

Currently Filament components using `->hiddenLabel()` will still show the label when printing.